### PR TITLE
add requirements for mybinder test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+scipy
+numpy
+pysal


### PR DESCRIPTION
Hey, 

trying to setup an environment on [mybinder.com](http://mybinder.org/) for the notebooks repository. This would gve us an immediately executable environment for the notebook repository. 

To do this, we need to specify dependencies required for the notebooks in a pip-style reqiurements.txt. So, I've done this.

Hopefully, if tihs works, we can add a badge (or a link, or whatever) on the main project that would drop people into an ipython notebook server up on mybinder.org with our examples, ready to execute in browser. 