### PR TITLE
ENH: Makefile for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# developer Makefile for repeated tasks
+# 
+
+.PHONY: clean
+
+nb:
+	docker run -it --rm  -p 8888:8888 -p 4000:4000 -v ${PWD}:/home/jovyan/work darribas/gds_dev:4.0
+
+term:
+	docker run -it --rm  -p 8888:8888 -p 4000:4000 -v ${PWD}:/home/jovyan/work darribas/gds_dev:4.0 sh -c "/bin/bash"
+
+
+clean: 
+	find . -name "*.pyc" -exec rm '{}' ';'
+	find pysal -name "__pycache__" -exec rm -rf '{}' ';'
+	rm -rf dist
+	rm -rf build
+	rm -rf PySAL.egg-info
+	rm -rf tmp
+


### PR DESCRIPTION
The current README instructions has the docker container not returning a shell for entry but rather the lab is running. It isn't clear how to move onto the build steps from that point.

The Makefile here is intended to support either running the lab in the container w/o a shell, or getting as shell.